### PR TITLE
Change README.md to rainfall

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,47 @@
-# Blame Pope Gregory XIII
+# 
 
-**Author:** Andrew Rosen
+**Author:** Elliot Soloway
 
 ## Abstract
 
-This lab is an exercise that goes over `if/else` statements or `switch` statements, modular arithmetic, String indices, and converting Strings to integers.  
-It is adapted from Savitch’s Java book.
+The rainfall problem is programming exercise where users input daily rainfall amounts until a sentinel value (e.g., -999) is entered, after which the program calculates and reports the total and average rainfall.
 
 ---
 
 ## 1. Assignment
+write a program that processes an input consisting of daily rainfall measurements (non-negative integers) until it encounters the integer -999. The program should output the average of the numbers. 
 
-Write a program that, given a string as an input, tests if the given string is a valid date in the Gregorian Calendar. Your program should output whether the given date is valid. If the given date is not valid, report why.
+**
+**Example:**
 
-- Dates in the US are formatted **MM/DD/YYYY**.
-- Valid months are in the range `[1, 12]`.
-- September, April, June, and November each have 30 days.
-- All other months but February have 31 days.
-- February has 28 days, except on a leap year, where it has 29.
+Enter daily rainfall amounts (enter -999 to stop):
 
-**Leap year rules:**
+10
 
-- A year not divisible by 4 is a normal year.
-- A year divisible by 4 is a leap year except...
-- A year divisible by 100 is not a leap year except...
-- A year divisible by 400 is a leap year.
+20
 
-**Examples:**
+0
 
-- 1644 → leap year
-- 1645 → not a leap year
-- 1600 → leap year
-- 1700 → not a leap year
+15
 
-You will need to think of a way to arrange the logic of these statements. Think about different ways to categorize leap years and non-leap years.
+-999
 
-> **Note:** The Gregorian Calendar is the most widely used civil calendar, instituted by Pope Gregory XIII (1572–1585). Some countries resisted using it until well into the 1900s.
+Total rainfall = 45.0
+
+Average rainfall = 11.25
 
 ---
 
-## 2. Hints
+## 2. Hint
 
-To complete this assignment, you will need to utilize some methods not used in class. Start by reading in the user’s input using `input()`.
+To complete this assignment. You will need to utilize user’s input using `input()`.
 
-### 2.1 Slicing a String
 
-To get a small portion of the string, use slice notation:
-
-```python
-s = "My name"
-
-s2 = s[0:2]  # "My"
-s3 = s[3:6]  # "nam"
-s4 = s[3:]   # "name"
-s5 = s[3]    # "n"
-space = s[2:3]  # " "
-```
-Slicing returns a substring from start to, but not including, end.
-Indices in Python start at 0.
-### 2.2 Converting Strings to Integers
-Use int() to convert a string into an integer:
-```python
-s = "123"
-i = int(s)  # 123
-```
-
-Combine this with slicing to extract the month, date, and year, then convert each into an int with int().
-The rest of the program is logic!
-
-### 2.3 Other Hints
-The month is the first thing you want to check.
-The year only matters in February.
-Work on the other months first.
 ## 3. Grading Criteria
-30 points – The program can tell if the input is a date.
-30 points – The program correctly handles non-leap year dates.
-30 points – The program correctly handles leap year dates.
+30 points – The program can tell if the input is valid.
+
+30 points – The program correctly outputs average.
+
+30 points – The program correctly outputs total.
+
 10 points – The source code is reasonably formatted.
-## 4. A Postscript About Time
-This program may have been difficult, but you have only scratched the surface. Time and dates are complicated by many factors, including daylight savings, odd time zones, historical calendar conversions, governmental policy, and leap seconds.
-Take this lesson to heart: Do not meddle with time.
-
-In your future career:
-
-Rely on libraries others have provided for you.
-Ask yourself: do you actually care about the actual time, or just internal consistency?
-📺 Video Reference: Computerphile – The Problem with Time & Dates (Tim Scott)


### PR DESCRIPTION
This pull request updates the `README.md` to replace the previous Gregorian Calendar date validation exercise with a new rainfall calculation programming exercise. The assignment, examples, hints, and grading criteria have all been rewritten to reflect the new requirements.

Assignment update:

* The programming exercise now asks users to input daily rainfall amounts until a sentinel value (-999) is entered, then calculates and reports the total and average rainfall. The previous date validation logic and leap year rules have been removed and replaced with rainfall-specific instructions and examples.
